### PR TITLE
Bumping ActiveDirectoryHelpers to 1.2.0.55 in \src\packages.config

### DIFF
--- a/src/packages.config
+++ b/src/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="us-ascii"?>
 <packages>
-	<package id="ActiveDirectoryHelpers" version="0.0.0.1" />
+	<package id="ActiveDirectoryHelpers" version="1.2.0.55" />
 	<package id="ALBHelpers" version="0.0.0.1" />
 	<package id="ALBMigrator" version="0.0.0.1" />
 </packages>


### PR DESCRIPTION
Bumping ActiveDirectoryHelpers to 1.2.0.55 in \src\packages.config